### PR TITLE
Working Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
             rule: install
 
           - btype: Debug
-            rule: debug install
+            rule: debug
 
     defaults:
       run:
@@ -154,7 +154,7 @@ jobs:
 
           - btype: Debug
             if: ${{ github.event_name != 'release' }}
-            rule: debug install
+            rule: debug
 
           - arch: x86
             use_sdl: USE_SDL=0
@@ -208,7 +208,7 @@ jobs:
             rule: install
 
           - btype: Debug
-            rule: debug install
+            rule: debug
 
     steps:
 
@@ -257,7 +257,7 @@ jobs:
             rule: install
 
           - btype: Debug
-            rule: debug install
+            rule: debug
 
     steps:
 

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -3411,6 +3411,8 @@ static void Sys_GetProcessorId( char *vendor )
 
 #else // not _WIN32
 
+#ifndef __APPLE__
+
 #include <sys/auxv.h>
 
 #if arm32
@@ -3464,6 +3466,8 @@ static void Sys_GetProcessorId( char *vendor )
 #endif
 #endif
 }
+
+#endif // !__APPLE__
 
 #endif // !_WIN32
 
@@ -3802,6 +3806,7 @@ void Com_Init( char *commandLine ) {
 
 	// CPU detection
 	Cvar_Get( "sys_cpustring", "detect", CVAR_PROTECTED | CVAR_ROM | CVAR_NORESTART );
+#ifndef __APPLE__
 	if ( !Q_stricmp( Cvar_VariableString( "sys_cpustring" ), "detect" ) )
 	{
 		char vendor[128];
@@ -3809,6 +3814,7 @@ void Com_Init( char *commandLine ) {
 		Sys_GetProcessorId( vendor );
 		Cvar_Set( "sys_cpustring", vendor );
 	}
+#endif
 	Com_Printf( "%s\n", Cvar_VariableString( "sys_cpustring" ) );
 
 #ifdef USE_AFFINITY_MASK

--- a/code/unix/linux_signals.c
+++ b/code/unix/linux_signals.c
@@ -51,7 +51,7 @@ static void signal_handler( int sig )
 	printf( "Received signal %d, exiting...\n", sig );
 
 #ifdef _DEBUG
-	if ( sig == SIGSEGV || sig == SIGILL || sig == SIGBUS )
+	//if ( sig == SIGSEGV || sig == SIGILL || sig == SIGBUS )
 	{
 		void *syms[10];
 		const size_t size = backtrace( syms, ARRAY_LEN( syms ) );


### PR DESCRIPTION
Here is one source that says the CPU name feature isn't available on Apple https://github.com/Dr-Noob/cpufetch/issues/47

Additionally, "debug install" in the build.yml with the option -j 8 is creating 8 jobs to compile files, but it is colliding with the command makedirs because it is running both debug and install at the same time, side by side, duplicating the calls to each file.

